### PR TITLE
fix[ios-#1527] Add Siren Test

### DIFF
--- a/Sources/Managers/APIManager.swift
+++ b/Sources/Managers/APIManager.swift
@@ -30,7 +30,7 @@ public struct APIManager {
     let countryCode: String?
 
     /// A property that can redirect the version check to a custom URL endpoint for testing purposes.
-    var customUrl: URL?
+    public var customUrl: URL?
 
     /// Initializes `APIManager` to the region or country of an App Store in which the app is available.
     /// By default, all version check requests are performed against the US App Store.

--- a/Sources/Managers/APIManager.swift
+++ b/Sources/Managers/APIManager.swift
@@ -29,6 +29,9 @@ public struct APIManager {
     ///
     let countryCode: String?
 
+    /// A property that can redirect the version check to a custom URL endpoint for testing purposes.
+    var customUrl: URL?
+
     /// Initializes `APIManager` to the region or country of an App Store in which the app is available.
     /// By default, all version check requests are performed against the US App Store.
     /// If the app is not available in the US App Store, set it to the identifier of at least one App Store region within which it is available.
@@ -58,7 +61,8 @@ extension APIManager {
 
         do {
             let url = try makeITunesURL()
-            let request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalAndRemoteCacheData, timeoutInterval: 30)
+            let resolvedUrl = customUrl ?? url
+            let request = URLRequest(url: resolvedUrl, cachePolicy: .reloadIgnoringLocalAndRemoteCacheData, timeoutInterval: 30)
             URLSession.shared.dataTask(with: request) { (data, response, error) in
                 URLCache.shared.removeCachedResponse(for: request)
                 self.processVersionCheckResults(withData: data, response: response, error: error, completion: handler)


### PR DESCRIPTION
Problem:
-------
We need to allow the APIManager URL to be customizable so we can point the Siren check request to a mock server.

Solution:
-------
Create a public var on APIManager that can be set outside of Siren.

Tests:
-------
No tests.
